### PR TITLE
Fix for and for-in in the parser

### DIFF
--- a/lib/parser.ometajs
+++ b/lib/parser.ometajs
@@ -218,13 +218,13 @@ ometa KrasotaJSParser {
     doStmt = stmtWithBlockStmt(#do):d sc:sc1
         keyword(#while) sc:sc2 bracketedExpr:be -> d.concat([sc1, sc2, be]),
 
-    forStmt = keyword(#for) sc:sc1 forStmtExprs:e sc:sc2 block:c -> [#forStmt, sc1, e, sc2, c],
+    forStmt = keyword(#for) sc:sc1 forStmtExprs:e sc:sc2 stmtContent:c -> [#forStmt, sc1, e, sc2, c],
     forStmtExprs = '(' (forStmtExpr1 | forStmtExpr):e1 ';' forStmtExpr:e2 ';' forStmtExpr:e3 ')' -> [e1, e2, e3],
     forStmtExpr1 = sc:sc1 varStmt:c sc:sc2 -> [#forStmtExpr, sc1, c, sc2],
     forStmtExpr = sc:sc1 expr:c sc:sc2 -> [#forStmtExpr, sc1, c, sc2]
         | sc:sc1 -> [#forStmtExpr, sc1],
 
-    forInStmt = keyword(#for) sc:sc1 forInStmtExpr:e sc:sc2 block:c -> [#forInStmt, sc1, e, sc2, c],
+    forInStmt = keyword(#for) sc:sc1 forInStmtExpr:e sc:sc2 stmtContent:c -> [#forInStmt, sc1, e, sc2, c],
     forInStmtExpr = '(' sc:sc1 (forInStmtVar | name):e1 sc:sc2 keyword('in') sc:sc3 asgnExpr:e2 sc:sc4 ')' -> [sc1, e1, sc2, sc3, e2, sc4],
     forInStmtVar = keyword(#var) varItemName:c -> [#varStmt, [c]],
 


### PR DESCRIPTION
ECMA allows non-block stmt as for and for-in bodies:
for (a in {}) launchMissile(); //is valid js
