### PR TITLE
Fix object properties in the parser

### DIFF
--- a/lib/parser.ometajs
+++ b/lib/parser.ometajs
@@ -139,7 +139,7 @@ ometa KrasotaJSParser {
     arrItem = sc:sc1 asgnExpr:e sc:sc2 -> [#arrItem, sc1, e, sc2],
 
     obj = '{' (commaList(#objItem) | sc):c '}' -> [#obj, c],
-    objItem = sc:sc1 (name | string):n sc:sc2
+    objItem = sc:sc1 (name | string | number | keyword(undefined)):n sc:sc2
         ':' sc:sc3 asgnExpr:v sc:sc4 -> [#objItem, sc1, n, sc2, sc3, v, sc4],
 
     re = string_('/'):c


### PR DESCRIPTION
Properties may be keywords and numbers. These should be valid:
var a = { 8: 42 };
var b = { for: 42 };
